### PR TITLE
Use lazy properties in the manifest extension

### DIFF
--- a/src/main/kotlin/com/coditory/gradle/manifest/ManifestPluginExtension.kt
+++ b/src/main/kotlin/com/coditory/gradle/manifest/ManifestPluginExtension.kt
@@ -1,9 +1,12 @@
 package com.coditory.gradle.manifest
 
-open class ManifestPluginExtension {
-    var classpathPrefix: String? = null
-    var attributes: Map<String, Any?>? = null
-    var implementationAttributes: Boolean = true
-    var buildAttributes: Boolean = true
-    var scmAttributes: Boolean = true
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+
+interface ManifestPluginExtension {
+    val classpathPrefix: Property<String>
+    val attributes: MapProperty<String, Any?>
+    val implementationAttributes: Property<Boolean>
+    val buildAttributes: Property<Boolean>
+    val scmAttributes: Property<Boolean>
 }

--- a/src/test/kotlin/com/coditory/gradle/manifest/GenerateManifestWithoutDisabledAttributesTest.kt
+++ b/src/test/kotlin/com/coditory/gradle/manifest/GenerateManifestWithoutDisabledAttributesTest.kt
@@ -10,7 +10,7 @@ class GenerateManifestWithoutDisabledAttributesTest {
     @Test
     fun `should generate manifest without scm attributes`() {
         // when
-        val manifest = project().generateManifest { it.scmAttributes = false }
+        val manifest = project().generateManifest { it.scmAttributes.set(false) }
         // then
         assertThat(manifest)
             .contains("Implementation-")
@@ -21,7 +21,7 @@ class GenerateManifestWithoutDisabledAttributesTest {
     @Test
     fun `should generate manifest without build attributes`() {
         // when
-        val manifest = project().generateManifest { it.buildAttributes = false }
+        val manifest = project().generateManifest { it.buildAttributes.set(false) }
         // then
         assertThat(manifest)
             .contains("Implementation-")
@@ -32,7 +32,7 @@ class GenerateManifestWithoutDisabledAttributesTest {
     @Test
     fun `should generate manifest without implementation attributes`() {
         // when
-        val manifest = project().generateManifest { it.implementationAttributes = false }
+        val manifest = project().generateManifest { it.implementationAttributes.set(false) }
         // then
         assertThat(manifest)
             .doesNotContain("Implementation-")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->
## Changes
This PR changes the manifest extension so that it uses lazy properties:

https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties

This seems like the way to go:

https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_configuration_roadmap

> Going forward, new properties will use the Provider API. The Groovy Gradle DSL adds convenience methods to make the use of Providers mostly transparent in build scripts. Existing tasks will have their existing "raw" properties replaced by Providers as needed and in a backwards compatible way. New tasks will be designed with the Provider API.

Note though, that it may break existing users using kotlin dsl.

My use case for this fix was to be able to set the Main-Class attribute to the value as defined by the application extension, when using lazy properties, this now works as expected:

```
application {
    mainClass.set("test.App")
}

manifest {
    attributes.set(mapOf(
        "Main-Class" to application.mainClass
    ))
}
```
Without it you would need some workaround, I believe the value could be moved out to a property, but this is less code. 

I haven't tested this thoroughly but it works for me.

## Checklist
- [x] I have tested that there is no similar [pull request](https://github.com/coditory/gradle-manifest-plugin/pulls) already submitted
- [x] I have read [contributing.md](https://github.com/coditory/gradle-manifest-plugin/blob/master/.github/CONTRIBUTING.md) and applied to the rules
- [x] I have unit tested code changes and performed a self-review
- [x] I have [tested plugin change locally](https://github.com/coditory/gradle-manifest-plugin/blob/master/.github/CONTRIBUTING.md#validate-changes-locally) on a sample project
